### PR TITLE
Limit caveats through aggregates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,5 +67,5 @@ pomExtra := <url>http://mimirdb.info</url>
 /////// Publishing Options ////////
 // use `sbt publish` to update the package in
 // your own local ivy cache
-
-publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
+publishTo := Some(Resolver.file("file",  new File("/var/www/maven_repo/")))
+// publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))

--- a/src/main/scala/org/mimirdb/utility/GenericObjectPrinter.scala
+++ b/src/main/scala/org/mimirdb/utility/GenericObjectPrinter.scala
@@ -159,9 +159,9 @@ object SparkTreePrinter {
       // this child in all children.
       case (name, value: TreeNode[_]) if o.containsChild(value) =>
         name -> JInt(o.children.indexOf(value))
-      case (name, value: Seq[T]) if value.forall(o.containsChild) =>
+      case (name, value: Seq[_]) if value.asInstanceOf[Seq[T]].forall(o.containsChild) =>
         name -> JArray(
-          value.map(v => JInt(o.children.indexOf(v.asInstanceOf[TreeNode[_]]))).toList
+          value.asInstanceOf[Seq[T]].map(v => JInt(o.children.indexOf(v.asInstanceOf[TreeNode[_]]))).toList
         )
       case (name, value) => name -> parseToJson(value)
     }.toList

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -11,6 +11,7 @@
   <logger name="org.mimirdb.caveats" level="ERROR" />
   <logger name="org.mimirdb.caveats.annotate.CaveatExistsInPlan" level="ERROR" />
   <logger name="org.mimirdb.lenses.inference.InferTypes$" level="ERROR" />
+  <logger name="org.mimirdb.caveats.enumerate.EnumeratePlanCaveats$" level="ERROR" />
   
   <root level="ERROR">
     <appender-ref ref="STDOUT" />

--- a/src/test/scala/org/mimirdb/caveats/GroupByAggSpec.scala
+++ b/src/test/scala/org/mimirdb/caveats/GroupByAggSpec.scala
@@ -1,0 +1,60 @@
+package org.mimirdb.caveats
+
+import org.apache.spark.sql.functions._
+import org.specs2.mutable.Specification
+import org.mimirdb.caveats.implicits._
+import org.mimirdb.test._
+
+class GroupByAggSpec
+  extends Specification
+  with SharedSparkTestInstance
+{
+
+  lazy val testDF = 
+    dfr.select( 
+          col("A").cast("int")
+                  .caveatIf("Hello", col("c") === 1) as "A",
+          col("B").cast("int") as "B"
+        )
+       .caveatIf("World", col("A") === 4)
+
+  "Filter caveats for one layer of aggregation" >> {
+
+    dfr.show()
+
+    val grouped =
+      testDF.groupBy("b").sum("A")
+
+    grouped.show()
+
+    val caveatFlags = 
+      grouped.trackCaveats
+             .collect()
+             .filter { row => !row.isNullAt(0) }
+             .map { row => 
+                row.getInt(0) -> 
+                (
+                  // Row Caveat
+                  row.getStruct(2)
+                     .getBoolean(0),
+                  // Sum(A) caveat
+                  row.getStruct(2)
+                     .getStruct(1)
+                     .getBoolean(1)
+                )
+             }.toMap
+
+    caveatFlags must contain( 2 -> (false, true) )
+
+    val caveatsOnTwo:Seq[String] =
+      grouped.filter(col("B") === 2)
+             .listCaveats()
+             .map { caveat => 
+               caveat.message
+             }
+
+    caveatsOnTwo must contain(eachOf("Hello", "World"))
+    caveatsOnTwo.filter { _.equals("Hello") }.size must beEqualTo(1)
+
+  }
+}


### PR DESCRIPTION
When enumerating caveats, Filter predicates are incorporated into the relevant "slice" of interest.  closes: https://github.com/VizierDB/web-ui/issues/222