### PR TITLE
Bugfixes and improvements to caveat enumeration on joins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 name := "mimir-caveats"
-version := "0.2.4"
+version := "0.2.5"
 organization := "org.mimirdb"
 scalaVersion := "2.12.10"
 

--- a/src/main/scala/org/mimirdb/caveats/enumerate/ExpressionDependency.scala
+++ b/src/main/scala/org/mimirdb/caveats/enumerate/ExpressionDependency.scala
@@ -79,6 +79,27 @@ class ExpressionDependency[T]
 object ExpressionDependency
 {
 
+  /**
+   * Collect data based on the dependencies of an expression.
+   * @param  expr       The expression to check for attribute dependencies
+   * @param  vSlice     The slice under which the dependency exists
+   * @param  aggregates How to interact with aggregate functions
+   * @param  detector   The collection rule visitor (slice => visitedExpr => output)
+   * @return            A slice (a map of exprID -> condition)
+   *
+   * A slice indicates some (potentially non-contiguous) region of a 
+   * dataframe.  A slice is normally given as Map of column/expression 
+   * pairs, where the expression indicates the subset of rows for which
+   * the given column is to be indicated.
+   * 
+   * apply() starts with the default slice given in vSlice, but 
+   * refines it as it iterates through the expression.  For example, 
+   * given the expression `A OR B`, the slice when visiting `A` will
+   * be `vSlice OR NOT B`.
+   * 
+   * The dectector is a partial function indicating which expressions
+   * need to be collected, and the left hand side input is the slice.
+   */
   def apply[T](
     expr: Expression, 
     vSlice: Expression = Literal(true),
@@ -87,6 +108,18 @@ object ExpressionDependency
     detector: Expression => PartialFunction[Expression, T]
   ) = new ExpressionDependency(detector, aggregates)(expr, vSlice, false)
 
+  /**
+   * Return the attributes on which a given expression depends, coupled
+   * with the conditions under which the dependency exists.
+   * @param  expr       The expression to check for attribute dependencies
+   * @param  vSlice     The slice under which the dependency exists
+   * @return            A slice (a map of exprID -> condition)
+   *
+   * A slice indicates some (potentially non-contiguous) region of a 
+   * dataframe.  A slice is normally given as Map of column/expression 
+   * pairs, where the expression indicates the subset of rows for which
+   * the given column is to be indicated.
+   */
   def attributes(
     expr: Expression,
     vSlice: Expression = Literal(true)

--- a/src/main/scala/org/mimirdb/caveats/implicits.scala
+++ b/src/main/scala/org/mimirdb/caveats/implicits.scala
@@ -177,10 +177,12 @@ class DataFrameImplicits(df:DataFrame)
                                 .analyzed
                                 .output
                                 .map { _.name }
-                                .toSet
+                                .toSet,
+    constraint: Column = lit(true)
   ) = EnumeratePlanCaveats(df.queryExecution.analyzed)(
         row = row,
-        attributes = attributes
+        attributes = attributes,
+        constraint = constraint.expr
       )
   def listCaveats(
     row: Boolean = true,
@@ -188,8 +190,10 @@ class DataFrameImplicits(df:DataFrame)
                                 .analyzed
                                 .output
                                 .map { _.name }
-                                .toSet
-  ) = listCaveatSets(row, attributes).flatMap { _.all(df.sparkSession) }
+                                .toSet,
+    constraint: Column = lit(true)
+  ) = listCaveatSets(row, attributes, constraint)
+        .flatMap { _.all(df.sparkSession) }
 
   def isAnnotated =
     df.queryExecution


### PR DESCRIPTION
The big thing here is with respect to slicing constraints.
EnumerateCaveats needs to know which subset of a dataframe it is
responsible for enumerating caveats on.  In order to do this, it
maintains something it calls a Slice: A set of column/expression pairs
that specify a column (that we're interested in caveats on), and a
boolean-valued expression (indicating for which rows we're interested in
caveats on the indicated column).  The same technique is used to
indicate for which rows we want caveats.

The problem is that with joins, it's possible for a single slice
condition to refer to expressions on both sides of the join.  Previously
this was handled for row-level conditions by setting the condition to
true (i.e., return ALL errors... a problem I think we might have a
Vizier issue for).  However, the same check was not happening for
attribute-level predicates.

This commit applies the correct behavior across the entire join, and
also refines it to use an Exists subquery to return a far smaller set of
caveats.

A few other adjustments
- Version bump to 0.2.5
- Added a bunch of comments
- Propagated constraint parameter to DataFrameImplicits.listCaveats
- spark.expressionLogic.attributesOfExpression now only returns
  correlated attributes for a nested subquery expression (as opposed to
  all attributes in the correlating expression)
- spark.expressionLogic.inline now ignores undefined attributes rather
  than replacing them.  This is a little less safe, but not doing this
  will require a TON of work to safely handle correlated subqueries.